### PR TITLE
Correction for LSession when it´s of type TJsonObject

### DIFF
--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -73,11 +73,13 @@ begin
         LJSON := LJWT.GetClaims.JSON;
 
         if Assigned(SessionClass) then
-          LSession := SessionClass.Create
+        begin
+          LSession := SessionClass.Create;
+          TJson.JsonToObject(LSession, LJSON);
+        end
         else
-          LSession := TJSONValue.Create;
+          LSession := LJWT.GetClaims.JSON.Clone;
 
-        TJson.JsonToObject(LSession, LJSON);
         THorseHackRequest(Req).SetSession(LSession);
       except
         on E: exception do


### PR DESCRIPTION
If you don´t pass a class class to the session parameter, it creates the session as a TJsonValue. The error is when using JsonToObject when the Session is a TJsonValue. And having the knowledge of parse work, parse always takes the name of the class variable (field), but TJsonValue will not have these fields. So, there is no way to feed the Session as a TJsonValue.