### PR TITLE
Gerava erro quando passado um Token inválido.

### DIFF
--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -152,7 +152,15 @@ begin
   LValidations := LBuilder.Build;
 
   try
-    LJWT := TJOSEContext.Create(LToken, TJWTClaims);
+    try
+      LJWT := TJOSEContext.Create(LToken, TJWTClaims);
+    except
+      on E: exception do
+      begin
+        AHorseResponse.Send('Invalid token authorization').Status(THTTPStatus.Unauthorized);
+        raise EHorseCallbackInterrupted.Create;
+      end;
+    end;
     try
       try
         LValidations.ProcessContext(LJWT);


### PR DESCRIPTION
Gerava erro quando passado um Token inválido.
Tratado para devolver mensagem "Invalid token authorization" quando ouver erro de conversão do Claims.

Exemplo Realizar a geração de um Token.
Na requisição passar passar um valor inválido para o "Beard token"