### PR TITLE
(fix) bypass root route in lazarus

### DIFF
--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -111,6 +111,7 @@ var
   LValidations: IJOSEConsumer;
   LJWT: TJOSEContext;
 {$ENDIF}
+  LPathInfo: string;
   LToken, LHeaderNormalize: string;
   LSession: TObject;
   LJSON: TJSONObject;
@@ -156,7 +157,10 @@ var
   end;
 {$ENDIF}
 begin
-  if MatchText(AHorseRequest.RawWebRequest.PathInfo, Config.SkipRoutes) then
+  LPathInfo := AHorseRequest.RawWebRequest.PathInfo;
+  if LPathInfo = EmptyStr then
+    LPathInfo := '/';
+  if MatchText(LPathInfo, Config.SkipRoutes) then
   begin
     ANext();
     Exit;


### PR DESCRIPTION
in Lazarus the Req.Web Request.PathInfo returns empty for the '/' route, so if this route is in the skip route, lazarus was not recognizing it.

``` delphi
  THorse.Use(HorseJWT('my-private-key', THorseJWTConfig.New.SkipRoutes(['/']) ));

  THorse
    .Get('/ping', GetPing)
    .Get('/', GetRoot);      
``` 