### PR TITLE
[feat] Implementado opção de HttpOnly para permitir setar token via Cookie

### DIFF
--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -191,6 +191,9 @@ begin
     LHeaderNormalize[1] := UpCase(LHeaderNormalize[1]);
 
   LToken := AHorseRequest.Headers[LConfig.Header];
+  if LToken.IsEmpty then
+    LToken := AHorseRequest.Cookie.Items[LConfig.Header];
+    
   if LToken.Trim.IsEmpty and not AHorseRequest.Query.TryGetValue(
     LConfig.Header, LToken) and not AHorseRequest.Query.TryGetValue(
     LHeaderNormalize, LToken) then


### PR DESCRIPTION
Com essa implementação é possivel enviar via Cookie durante a geração apenas enviando Header ex:

```
CookieHeader := 'authorization=bearer ' + Token.GetValue('token').Value +'; Max-Age=3600; Path=/; HttpOnly';
 Res.AddHeader('Set-Cookie', CookieHeader);
```


