### PR TITLE
Fixed the handling of the Authorization header string regarding the c…

### DIFF
--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -262,7 +262,8 @@ begin
   LToken := AHorseRequest.Headers[LHeaderNormalize];
   if LToken.IsEmpty then
   begin
-    LHeaderNormalize := LConfig.Header.Substring(0, 1).ToUpper + LConfig.Header.Substring(1);
+    if Length(LHeaderNormalize) > 0 then
+      LHeaderNormalize[1] := UpCase(LHeaderNormalize[1]);
     LToken := AHorseRequest.Headers[LHeaderNormalize];
   end;
 

--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -259,12 +259,15 @@ begin
 
   LHeaderNormalize := LConfig.Header;
 
-  if Length(LHeaderNormalize) > 0 then
-    LHeaderNormalize[1] := UpCase(LHeaderNormalize[1]);
-
-  LToken := AHorseRequest.Headers[LConfig.Header];
+  LToken := AHorseRequest.Headers[LHeaderNormalize];
   if LToken.IsEmpty then
-    LToken := AHorseRequest.Cookie.Items[LConfig.Header];
+  begin
+    LHeaderNormalize := LConfig.Header.Substring(0, 1).ToUpper + LConfig.Header.Substring(1);
+    LToken := AHorseRequest.Headers[LHeaderNormalize];
+  end;
+
+  if LToken.IsEmpty then
+    LToken := AHorseRequest.Cookie.Items[LHeaderNormalize];
 
   if LToken.Trim.IsEmpty and not AHorseRequest.Query.TryGetValue(
     LConfig.Header, LToken) and not AHorseRequest.Query.TryGetValue(


### PR DESCRIPTION
If the client sent the request with the "Authorization" header string having the first character capitalized, the "Token not found" error occurred.

Tests performed using an Axios interceptor:

      config.headers.Authorization = `Bearer ${token}`; // Fail
      config.headers["Authorization"] = `Bearer ${token}`; // Fail
      config.headers["authorization"] = `Bearer ${token}`; // Success

Added handling for this situation.
