### PR TITLE
refactor: allow reading JWT payload from Services container to avoid …

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,64 @@ begin
 end.
 ```
 
+#### How to read the Payload from Services container (Avoiding Session conflicts)
+
+If you need to use `Req.Session` for other purposes in your application (e.g. database sessions or custom user profiles), you can retrieve the JWT payload safely from the `Req.Services` dependency injection container:
+
+```delphi
+uses
+  Horse, Horse.JWT,
+  MyClaims in 'MyClaims.pas',
+  System.SysUtils;
+
+begin
+  THorse
+    .AddCallback(HorseJWT('MY-PASSWORD', THorseJWTConfig.New.SessionClass(TMyClaims)))
+    .Get('ping', 
+      procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+      var
+        LClaims: TMyClaims;
+      begin
+        // Retrieve claims safely from Req.Services instead of Req.Session
+        LClaims := Req.Services.Resolve(TMyClaims) as TMyClaims;
+
+        Res.Send(Format('Hello %s, your email is %s', [LClaims.Name, LClaims.Email]));
+      end);
+
+  THorse.Listen(9000);
+end.
+```
+
+If you are **not** using a custom `SessionClass` configuration, the payload will be registered as a standard `TJSONObject`. You can retrieve it like this:
+
+```delphi
+uses
+  Horse, Horse.JWT,
+  System.JSON,
+  System.SysUtils;
+
+begin
+  THorse.Use(HorseJWT('MY-PASSWORD'));
+
+  THorse.Get('/ping', 
+    procedure(Req: THorseRequest; Res: THorseResponse; Next: TProc)
+    var
+      LClaims: TJSONObject;
+    begin
+      // Retrieve the default JSON payload safely from Req.Services
+      LClaims := Req.Services.Resolve(TJSONObject) as TJSONObject;
+
+      Res.Send('Subject: ' + LClaims.GetValue('sub').Value);
+    end);
+
+  THorse.Listen(9000);
+end.
+```
+
+> [!NOTE]  
+> Under Lazarus/FPC, import `fpjson` instead of `System.JSON` to work with the default `TJSONObject`.
+
+
 #### How to create public and private routes?
 
 ```Delphi

--- a/src/Horse.JWT.pas
+++ b/src/Horse.JWT.pas
@@ -1,4 +1,4 @@
-﻿unit Horse.JWT;
+unit Horse.JWT;
 
 {$IF DEFINED(FPC)}
   {$MODE DELPHI}{$H+}
@@ -382,6 +382,13 @@ begin
           LSession := LJSON;
 {$ENDIF}
         AHorseRequest.Session(LSession);
+        if Assigned(LSession) then
+        begin
+          if Assigned(LConfig.SessionClass) then
+            AHorseRequest.Services.Add(LConfig.SessionClass, LSession, False)
+          else
+            AHorseRequest.Services.Add(LSession.ClassType, LSession, False);
+        end;
       except
         on E: Exception do
         begin


### PR DESCRIPTION
# Descrição

Este PR resolve o problema onde o middleware `horse-jwt` sequestrava exclusivamente a propriedade `THorseRequest.Session` para guardar o payload JWT decodificado. Ao fazer isso, impedia os desenvolvedores de utilizarem `Req.Session` para propósitos específicos da própria aplicação (como conexões de banco de dados, perfis de usuários ou controle local de sessões).

### Alterações Propostas:
1. **Registro no Container de Serviços (Injeção de Dependências):**
   - O payload decodificado (`LSession`) passa a ser registrado no container de escopo da requisição `AHorseRequest.Services`.
   - O registro é efetuado passando o parâmetro `AOwns := False`, garantindo que o container de serviços do Horse não tente liberar a memória de `LSession`. A liberação do objeto continua sob responsabilidade segura do bloco `finally` do pipeline do middleware `horse-jwt`.
2. **Preservação de Retrocompatibilidade:**
   - A atribuição original `AHorseRequest.Session(LSession)` foi mantida ativa. Com isso, aplicações existentes que recuperam claims através de `Req.Session<T>` continuarão compilando e funcionando normalmente.
3. **Programação Defensiva:**
   - Adicionada uma verificação de guarda (`if Assigned(LSession)`) para garantir que o objeto de sessão/claims foi corretamente instanciado antes de tentar recuperar a sua classe (`LSession.ClassType`) e registrá-lo no container de serviços.
4. **Documentação:**
   - O arquivo `README.md` foi atualizado com instruções detalhadas e exemplos de código sobre como obter o payload via `Req.Services` (tanto para classes customizadas de claims, usando `SessionClass`, quanto para a configuração default que retorna um `TJSONObject`).

## Issues Relacionadas
Sana a issue https://github.com/HashLoad/horse/issues/529

## Plano de Verificação

### Verificação Manual
- Verificação da compilação e execução dos projetos de exemplo em Delphi.
- Garantia de que a configuração default registra e resolve `TJSONObject` e a configuração customizada resolve a classe `TMyClaims` adequadamente no container.
