### PR TITLE
chore(deps): update horse dependency to ^3.3.0

### DIFF
--- a/boss.json
+++ b/boss.json
@@ -7,7 +7,7 @@
 	"projects": [],
 	"dependencies": {
 		"github.com/andre-djsystem/hashlib4pascal": "^1.0.0",
-		"github.com/hashload/horse": "^3.1.4",
+		"github.com/hashload/horse": "^3.3.0",
 		"github.com/paolo-rossi/delphi-jose-jwt": "^v3.2.0"
 	}
 }

--- a/samples/delphi/auth/boss.json
+++ b/samples/delphi/auth/boss.json
@@ -6,7 +6,7 @@
 	"mainsrc": "./",
 	"projects": [],
 	"dependencies": {
-		"github.com/hashload/horse": "^3.1.0",
+		"github.com/hashload/horse": "^3.3.0",
 		"github.com/hashload/jhonson": "^1.1.5",
 		"github.com/paolo-rossi/delphi-jose-jwt": "^v3.2.0"
 	}

--- a/samples/delphi/client/boss.json
+++ b/samples/delphi/client/boss.json
@@ -6,7 +6,7 @@
 	"mainsrc": "./",
 	"projects": [],
 	"dependencies": {
-		"github.com/hashload/horse": "^3.1.4",
+		"github.com/hashload/horse": "^3.3.0",
 		"github.com/paolo-rossi/delphi-jose-jwt": "^v3.2.0"
 	}
 }

--- a/samples/delphi/session/boss.json
+++ b/samples/delphi/session/boss.json
@@ -6,7 +6,7 @@
 	"mainsrc": "./",
 	"projects": [],
 	"dependencies": {
-		"github.com/hashload/horse": "^3.1.0",
+		"github.com/hashload/horse": "^3.3.0",
 		"github.com/hashload/horse-jwt": "^2.0.12",
 		"github.com/hashload/jhonson": "^1.1.5",
 		"github.com/paolo-rossi/delphi-jose-jwt": "^v3.2.0"

--- a/samples/lazarus/client/boss.json
+++ b/samples/lazarus/client/boss.json
@@ -7,6 +7,6 @@
 	"projects": [],
 	"dependencies": {
 		"github.com/andre-djsystem/hashlib4pascal": "^1.0.0",
-		"github.com/hashload/horse": "^3.1.0"
+		"github.com/hashload/horse": "^3.3.0"
 	}
 }


### PR DESCRIPTION
## Description
Bump framework version to `3.3.0` to support context dependency injection (`Services`) properly inside the ecosystem packages (such as `horse-jwt`).

## Related Issues
- Relates to changes in `horse-jwt` using `AHorseRequest.Services`.

## Checklist
- [x] Version updated in `boss.json`
